### PR TITLE
Set proper default value for update interval

### DIFF
--- a/pyess-addon/config.yaml
+++ b/pyess-addon/config.yaml
@@ -17,7 +17,7 @@ options:
   ess_host: "127.0.0.1"
   ess_password: "ess_password"
   ess_sensors: "ess/common/BATT/soc,ess/home/statistics/pcs_pv_total_power,ess/common/GRID/active_power,ess/common/LOAD/load_power,ess/common/PCS/month_pv_generation_sum,ess/common/PCS/month_grid_feed_in_energy,ess/home/statistics/batconv_power,ess/common/BATT/month_batt_charge_energy,ess/common/BATT/month_batt_discharge_energy,ess/common/GRID/month_grid_power_purchase_energy,ess/control/active"
-  ess_update_interval: "ess_password"
+  ess_update_interval: 10
 
 schema:
   ess_host: "str?"


### PR DESCRIPTION
By introducing an option for the update interval previous configurations were broken due to improper default value.

This PR introduce a proper int value, set as the default value in the pyess client it self.

Otherwise, it would be possible to not provide a default value at all and call essmqtt without any update interval. This would use the default update interval as given in essmqtt.py